### PR TITLE
Fix bug in match no data value function

### DIFF
--- a/Examples/prepare_inputdata
+++ b/Examples/prepare_inputdata
@@ -58,12 +58,26 @@ system of the second raster and give it the same alignment like a source raster 
 dem_path="Data/GIS/acc4000.tif"
 soil_path="Data/GIS/soil_raster.tif"
 DEM=gdal.Open(dem_path)
+dem_A=DEM.ReadAsArray()
 soil=gdal.Open(soil_path)
+soil_A=soil.ReadAsArray()
 
+# align
 aligned_soil=GIS.MatchRasterAlignment(DEM,soil)
+
 # to check alignment of DEM raster compared to aligned_soil_A raster
 aligned_soil_A=aligned_soil.ReadAsArray()
 dem_A=DEM.ReadAsArray()
+# nodatavalue is still different and some cells are no data value in the soil type raster but it is not in the dem raster
+# to match use Match MatchNoDataValue
+# match
+dst_Aligned_M=GIS.MatchNoDataValue(DEM,aligned_soil)
+dst_Aligned_M_A=dst_Aligned_M.ReadAsArray()
 
 # save the new raster
-GIS.SaveRaster(aligned_soil,"soil_type.tif")
+GIS.SaveRaster(dst_Aligned_M,"soil_type.tif")
+
+
+
+
+GIS.SaveRaster(dst_Aligned_M,"00inputs/GIS/4000/soil_typeِِA.tif")


### PR DESCRIPTION
# align function only equate the no of rows and columns only
# match nodatavalue inserts nodatavalue in dst raster to all places like src
# still places that has nodatavalue in the dst raster but it is not nodatavalue in the src 
# and now has to be filled with values
# compare no of element that is not nodata value in both rasters to make sure they are matched
if not equal then store indices of those cells that doesn't matchs
# interpolate those missing cells by nearest neighbour